### PR TITLE
PREDICT: Add support for batch process

### DIFF
--- a/src/readability_classifier/encoders/dataset_encoder.py
+++ b/src/readability_classifier/encoders/dataset_encoder.py
@@ -163,11 +163,10 @@ class DatasetEncoder(EncoderInterface):
         return torch.tensor(scores)
 
 
-def decode_score(score: Tensor) -> tuple[str, float]:
+def decode_score(score: float) -> tuple[str, float]:
     """
     Decodes the given score to a tuple with class and score.
     :param score: The score to decode.
     :return: The decoded score.
     """
-    score = score.item()
     return "Readable" if score > 0.5 else "Unreadable", score

--- a/src/readability_classifier/keas/model_runner.py
+++ b/src/readability_classifier/keas/model_runner.py
@@ -115,7 +115,7 @@ class KerasModelRunner(ModelRunnerInterface):
         # Predict the readability of the snippet
         towards_input = convert_to_towards_input_without_score(encoded_data)
         prediction = model.predict(towards_input)
-        prediction = decode_score(prediction)
+        prediction = decode_score(prediction.item())
         logging.info(f"Readability of snippet: {prediction}")
         return prediction
 


### PR DESCRIPTION
Add support to process a whole directory and additional print the average readability over it.

That is more efficient, in the memory usage, than running them all in parallel, because the model itself consumes the most memory and not the input files.