### PR TITLE
Fix predict example

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -99,7 +99,7 @@ Example:
 
 [source,bash]
 ----
-python src/readability_classifier/main.py PREDICT --model tests/res/models/towards.h5 --input <snippet_path>
+python src/readability_classifier/main.py PREDICT --model tests/res/models/towards.h5 --input tests/res/code_snippets/towards.java
 ----
 
 [[Train]]

--- a/README.adoc
+++ b/README.adoc
@@ -99,7 +99,7 @@ Example:
 
 [source,bash]
 ----
-python src/readability_classifier/main.py PREDICT --model tests/res/models/model.pt --input <snippet_path>
+python src/readability_classifier/main.py PREDICT --model tests/res/models/towards.h5 --input <snippet_path>
 ----
 
 [[Train]]


### PR DESCRIPTION
- Correct wrong name of the model file 1d5430027c146c18eaf5603d8a20dafda482d538
- Replace `<snippet_path>` with the path of an example snippet c8194a9675a95743339bd8aa9eec6ed512fa6d2a

:arrow_right:  Same, working example as in the predict branch also for the main branch