### PR TITLE
Batch performance

### DIFF
--- a/src/readability_classifier/encoders/dataset_encoder.py
+++ b/src/readability_classifier/encoders/dataset_encoder.py
@@ -56,9 +56,11 @@ class DatasetEncoder(EncoderInterface):
         bert_dataset = self.bert_encoder.encode_dataset(unencoded_dataset)
         image_dataset = self.visual_encoder.encode_dataset(unencoded_dataset)
 
-        # Normalize the scores
-        scores = [sample["score"] for sample in unencoded_dataset]
-        encoded_scores = self._encode_scores_class(scores)
+        # Normalize the scores if they exist
+        encoded_scores = ["" for _ in range(len(matrix_dataset))]
+        if "scores" in unencoded_dataset[0]:
+            scores = [sample["score"] for sample in unencoded_dataset]
+            encoded_scores = self._encode_scores_class(scores)
 
         # Get the names, if they exist
         names = ["" for _ in range(len(matrix_dataset))]

--- a/src/readability_classifier/encoders/dataset_encoder.py
+++ b/src/readability_classifier/encoders/dataset_encoder.py
@@ -58,7 +58,7 @@ class DatasetEncoder(EncoderInterface):
 
         # Normalize the scores if they exist
         encoded_scores = ["" for _ in range(len(matrix_dataset))]
-        if "scores" in unencoded_dataset[0]:
+        if "score" in unencoded_dataset[0]:
             scores = [sample["score"] for sample in unencoded_dataset]
             encoded_scores = self._encode_scores_class(scores)
 

--- a/src/readability_classifier/main.py
+++ b/src/readability_classifier/main.py
@@ -5,11 +5,10 @@ import sys
 from argparse import ArgumentParser
 from enum import Enum
 from pathlib import Path
-from typing import Any, AnyStr
+from typing import Any
 
 from src.readability_classifier.encoders.dataset_encoder import (
     DatasetEncoder,
-    decode_score,
 )
 from src.readability_classifier.encoders.dataset_utils import (
     load_encoded_dataset,
@@ -370,39 +369,35 @@ def _run_predict(parsed_args, model_runner: ModelRunnerInterface) -> tuple[str, 
     :return: None
     """
     data_arg = parsed_args.input
-    data_inputs: list[AnyStr] = []
 
     # Load the snippet
     if os.path.isfile(data_arg):
-        with open(data_arg) as file:
-            data_inputs.append(file.read())
+        files = [data_arg]
     else:
         if os.path.isdir(data_arg):
+            files = []
             for name in os.listdir(data_arg):
                 f = os.path.join(data_arg, name)
                 if os.path.isfile(f) and f.endswith(".java"):
-                    with open(f) as file:
-                        data_inputs.append(file.read())
+                    files.append(f)
+            if len(files) == 0:
+                raise FileNotFoundError(f"No java files in {data_arg} found.")
         else:
             raise FileNotFoundError(f"{data_arg} does not exist.")
+    data_inputs: list[dict] = []
+    for f in files:
+        with open(f) as file:
+            file_contents = file.read()
+            logging.info("Loaded Snippet: \n %s", file_contents)
+            data_inputs.append({"code_snippet": file_contents})
 
-    score_sum: float = 0.0
-    for data_input in data_inputs:
-        logging.info("Loaded Snippet: \n %s", data_input)
+    # Encode the snippet
+    logging.info("Encoding Snippets...")
+    encoded_snippets = DatasetEncoder().encode_dataset(data_inputs)
 
-        # Encode the snippet
-        logging.info("Encoding Snippet...")
-        encoded_snippet = DatasetEncoder().encode_text(data_input)
-
-        # Run the prediction
-        logging.info("Predicting Readability...")
-
-        result = model_runner.run_predict(parsed_args, encoded_snippet)
-        score_sum += result[1]
-    avg = score_sum / len(data_inputs)
-    prediction = decode_score(avg)
-    logging.info(f"Readability of directory: {prediction}")
-    return prediction
+    # Run the prediction
+    logging.info("Predicting Readability...")
+    return model_runner.run_predict(parsed_args, encoded_snippets)
 
 
 def _run_evaluate(parsed_args, model_runner: ModelRunnerInterface) -> None:

--- a/tests/readability_classifier/keas/test_model_runner.py
+++ b/tests/readability_classifier/keas/test_model_runner.py
@@ -56,12 +56,13 @@ class TestKerasModelRunner(DirTest):
 
         # Get the encoded data
         code = read_content_of_file(TOWARDS_CODE_SNIPPET)
-        encoded_data = DatasetEncoder().encode_text(code)
+        dataset = [{'name': TOWARDS_CODE_SNIPPET, 'code_snippet': code}]
+        encoded_dataset = DatasetEncoder().encode_dataset(dataset)
 
         # Run the model runner
         model_runner = KerasModelRunner()
         clazz, score = model_runner.run_predict(
-            parsed_args=MockParsedArgs(), encoded_data=encoded_data
+            parsed_args=MockParsedArgs(), encoded_dataset=encoded_dataset
         )
 
         assert clazz == "Readable"

--- a/tests/readability_classifier/keas/test_model_runner.py
+++ b/tests/readability_classifier/keas/test_model_runner.py
@@ -66,7 +66,7 @@ class TestKerasModelRunner(DirTest):
         )
 
         assert clazz == "Readable"
-        assert score == 0.9931080341339111
+        assert 0.99 < score < 1
 
     def test_run_evaluate(self):
         # Mock the parsed arguments

--- a/tests/readability_classifier/test_main.py
+++ b/tests/readability_classifier/test_main.py
@@ -75,7 +75,7 @@ class TestRunMain(DirTest):
     def test_run_predict(self):
         class MockParsedArgs:
             def __init__(self):
-                self.input = BW_SNIPPET_1
+                self.input = [BW_SNIPPET_1]
                 self.model = TOWARDS_MODEL
 
         parsed_args = MockParsedArgs()

--- a/tests/readability_classifier/test_main.py
+++ b/tests/readability_classifier/test_main.py
@@ -84,4 +84,4 @@ class TestRunMain(DirTest):
         clazz, score = _run_predict(parsed_args, model_runner)
 
         assert clazz == "Readable"
-        assert score == 0.9999087452888489
+        assert 0.99 < score < 1

--- a/tests/readability_classifier/test_main.py
+++ b/tests/readability_classifier/test_main.py
@@ -15,6 +15,9 @@ from tests.readability_classifier.utils.utils import (
     RAW_BW_DIR,
     TOWARDS_MODEL,
     DirTest,
+    TOWARDS_CODE_SNIPPET,
+    DIR_WITH_ONE_SNIPPET,
+    DIR_WITH_FOUR_SNIPPETS,
 )
 
 
@@ -85,3 +88,17 @@ class TestRunMain(DirTest):
 
         assert clazz == "Readable"
         assert 0.99 < score < 1
+
+    def test_run_predict_batch(self):
+        class MockParsedArgs:
+            def __init__(self):
+                self.input = [TOWARDS_CODE_SNIPPET, DIR_WITH_ONE_SNIPPET, DIR_WITH_FOUR_SNIPPETS]
+                self.model = TOWARDS_MODEL
+
+        parsed_args = MockParsedArgs()
+        model_runner = KerasModelRunner()
+
+        clazz, score = _run_predict(parsed_args, model_runner)
+
+        assert clazz == "Readable"
+        assert 0.56 < score < 0.57

--- a/tests/readability_classifier/utils/utils.py
+++ b/tests/readability_classifier/utils/utils.py
@@ -34,6 +34,8 @@ STATS_FILE = HISTORY_DIR / "stats.json"
 
 CODE_SNIPPETS_DIR = RES_DIR / "code_snippets"
 TOWARDS_CODE_SNIPPET = CODE_SNIPPETS_DIR / "towards.java"
+DIR_WITH_ONE_SNIPPET = CODE_SNIPPETS_DIR / "AreaShop/AreaShopInterface.java"
+DIR_WITH_FOUR_SNIPPETS = CODE_SNIPPETS_DIR / "AreaShop/AddCommand.java"
 
 
 class DirTest(unittest.TestCase):


### PR DESCRIPTION
Improving performance of PREDICT of many files and folders:

1. Use batch encoding
2. Move the loop for the files into the modul_runner (only one initialization of the model necessary)
3. Support more than one file / folder as input to increase the batch size (also adding file / folder names to output, to make it easier to match the outputs with the list of input files and folders)

Already step 1 decreased the execution time in my situation (almost 100 folders). With CPU execution the decrease if about 50 % and with GPU execution it is about 25 %. (For the other steps I am actually adjusting my shell scripts to use these improvements.)

I adjusted the tests to fit the new parameter types. However, they're still failing (score differs slightly), but they had already failed before my changes. @LuKrO2011 Were there some breaking changes (e.g., new model files)? When this is fixed: Should I add tests for predicting several input folders?